### PR TITLE
AP_Bootloader: Reserve Aocoda-RC board IDs and apply for H743DUAL/F405V3

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -267,10 +267,10 @@ AP_HW_VIMDRONES_MOSAIC_H             1406
 AP_HW_VIMDRONES_PERIPH               1407
 
 # IDs 5000-5099 reserved for Carbonix
-# IDs 5200-5209 reserved for Airvolute
-AP_HW_AIRVOLUTE_DCS2             5200
-
 # IDs 5100-5199 reserved for SYPAQ Systems
+# IDs 5200-5209 reserved for Airvolute
+AP_HW_AIRVOLUTE_DCS2                 5200
+
 # IDs 6000-6099 reserved for SpektreWorks
 
 # OpenDroneID enabled boards. Use 10000 + the base board ID

--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -271,6 +271,10 @@ AP_HW_VIMDRONES_PERIPH               1407
 # IDs 5200-5209 reserved for Airvolute
 AP_HW_AIRVOLUTE_DCS2                 5200
 
+# IDs 5210-5219 reserved for Aocoda-RC
+AP_HW_AOCODA-RC-H743DUAL             5210
+AP_HW_AOCODA-RC-F405V3               5211
+
 # IDs 6000-6099 reserved for SpektreWorks
 
 # OpenDroneID enabled boards. Use 10000 + the base board ID


### PR DESCRIPTION
AP_Bootloader: Reserve Aocoda-RC board IDs and apply for H743DUAL/F405V3